### PR TITLE
feat: Adding ability to use name site

### DIFF
--- a/terraform/certs.tf
+++ b/terraform/certs.tf
@@ -1,0 +1,14 @@
+resource "aws_acm_certificate" "ssl_certificate" {
+  domain_name               = var.site_name
+  subject_alternative_names = ["www.${var.site_name}"]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "cert_validation" {
+  certificate_arn = aws_acm_certificate.ssl_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.my_validation_record : record.fqdn]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   comment             = "CloudFront for my resume site"
   default_root_object = "Alvaro_E_resume.html"
 
+  aliases = [var.site_name, "www.${var.site_name}"]
+
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
@@ -140,6 +142,10 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = aws_acm_certificate.ssl_certificate.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+    #cloudfront_default_certificate = true -- Use for testing just CloudFront, but comment out above parameters
   }
+
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,45 @@
+resource "aws_route53_zone" "primary" {
+  name = var.site_name
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "www.${var.site_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.site_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# resource "aws_route53_record" "cert_validation" {
+resource "aws_route53_record" "my_validation_record" {
+  for_each = {
+    for dvo in aws_acm_certificate.ssl_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  zone_id         = aws_route53_zone.primary.zone_id
+  ttl             = 60
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,13 @@ variable "region" {
   type = string
   default = "us-east-1"
 }
+
+variable "site_name" {
+  type = string
+  description = "The domain or site to use"
+}
+
+variable "ttl" {
+  type = number
+  default = 60
+}


### PR DESCRIPTION
Will be using AWS's Route 53 to use a site instead of the CloudFront domain name